### PR TITLE
Switch '/api/chat' to Node.js from Edge.

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,7 +6,7 @@ import Speech from 'lmnt-node';
 import { auth } from '@/auth'
 import { nanoid } from '@/lib/utils'
 
-export const runtime = 'edge'
+// export const runtime = 'edge'
 
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY

--- a/components/audio-playbar.tsx
+++ b/components/audio-playbar.tsx
@@ -1,4 +1,4 @@
-import { use, useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 export interface AudioPlaybarProps {
   audioData: ArrayBuffer[]

--- a/components/empty-screen.tsx
+++ b/components/empty-screen.tsx
@@ -28,9 +28,12 @@ export function EmptyScreen({ setInput }: Pick<UseChatHelpers, 'setInput'>) {
         </h1>
         <p className="mb-2 leading-normal text-muted-foreground">
           This is an open source AI chatbot app template built with{' '}
-          <ExternalLink href="https://nextjs.org">Next.js</ExternalLink> and{' '}
+          <ExternalLink href="https://nextjs.org">Next.js</ExternalLink>,{' '}
           <ExternalLink href="https://vercel.com/storage/kv">
             Vercel KV
+          </ExternalLink> and{' '}
+          <ExternalLink href="https://lmnt.com/">
+            LMNT
           </ExternalLink>
           .
         </p>

--- a/lib/audio-utils.ts
+++ b/lib/audio-utils.ts
@@ -7,17 +7,3 @@ export function base64ToArrayBuffer(base64: string): ArrayBuffer {
   }
   return bytes.buffer
 }
-
-export const decodeMonoMpegAudioData = (mpegData: ArrayBuffer): Promise<Float32Array> => {
-  return new Promise((resolve, reject) => {
-    const audioContext = new window.AudioContext()
-    audioContext.decodeAudioData(mpegData, (audioBuffer) => {
-      if (audioBuffer.numberOfChannels !== 1) {
-        reject(new Error('Expected mono audio'))
-      }
-      resolve(audioBuffer.getChannelData(0))
-    }, (error) => {
-      reject(error)
-    })
-  })
-}


### PR DESCRIPTION
Exploring whether this fixes websocket usage in deployment.

A few other minor edits:
- LMNT on empty page.
- Remove unused mp3 decode in audio-utils.
- Remove unused import in playbar.